### PR TITLE
Shortcut to produce submit descriptions from "working" commands

### DIFF
--- a/globus.py
+++ b/globus.py
@@ -306,7 +306,7 @@ def endpoints(settings, limit):
     """
     List endpoints.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     endpoints = list(tc.endpoint_search(filter_scope="my-endpoints", num_results=limit))
 
@@ -331,7 +331,7 @@ def info(settings, endpoint):
 
     Although mostly intended for human consumption, the output is valid JSON.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     info = EndpointInfo.get_or_exit(tc, endpoint)
 
@@ -362,7 +362,7 @@ def history(settings, limit):
     """
     List transfer events.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
     tasks = [task.data for task in tc.task_list(num_results=limit)]
     for task in tasks:
         if task["label"] is None:
@@ -400,7 +400,7 @@ def ls(settings, endpoint, path):
     This command is intended to produce human-readable output. The "manifest"
     command is more useful as part of a workflow.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     activate_endpoint_or_exit(tc, endpoint)
 
@@ -442,7 +442,7 @@ def manifest(settings, endpoint, path, verbose):
     else:
         json_dumps_kwargs = dict(indent=None, separators=(",", ":"))
 
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     activate_endpoint_or_exit(tc, endpoint)
 
@@ -457,7 +457,7 @@ def activate(settings, endpoint):
     """
     Activate a Globus endpoint.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     activate_endpoint_or_exit(tc, endpoint)
 
@@ -552,11 +552,19 @@ def transfer(
         universe = local
         executable = {exe}
         arguments = {" ".join((arg for arg in args if arg != AS_JOB))}
+        log = {'transfer_job_$(CLUSTER)_$(PROCESS).log'}
+        output = {'transfer_job_$(CLUSTER)_$(PROCESS).out'}
+        error = {'transfer_job_$(CLUSTER)_$(PROCESS).err'}
+        request_cpus = 1
+        request_memory = 200MB
+        request_disk = 1GB
+
+        queue 1
         """
         click.secho(textwrap.dedent(desc).lstrip())
         return
 
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     tdata = globus_sdk.TransferData(
         tc, source_endpoint, destination_endpoint, label=label, sync_level="checksum"
@@ -604,7 +612,7 @@ def cancel(settings, task_id):
     """
     Cancel a task.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     try:
         result = tc.cancel_task(task_id)
@@ -633,7 +641,7 @@ def wait(settings, task_id, timeout, interval, attempts):
     """
     Wait for a task to complete.
     """
-    tc = get_transfer_client_or_exit(settings[AUTH].get_or_exit(REFRESH_TOKEN))
+    tc = get_transfer_client_or_exit(settings[AUTH].get(REFRESH_TOKEN))
 
     wait_for_task_or_exit(
         transfer_client=tc,
@@ -747,7 +755,7 @@ def table(
 
     processed_rows = []
     for row in rows:
-        processed_rows.append([str(row.get_or_exit(key, fill)) for key in headers])
+        processed_rows.append([str(row.get(key, fill)) for key in headers])
 
     for row in processed_rows:
         lengths = [max(curr, len(entry)) for curr, entry in zip(lengths, row)]

--- a/globus.py
+++ b/globus.py
@@ -82,9 +82,9 @@ def cli(context, verbose, as_submit_description):
             executable = {exe}
             arguments = {args_string}
 
-            log = {'globus_job_$(CLUSTER)_$(PROCESS).log'}
-            output = {'globus_job_$(CLUSTER)_$(PROCESS).out'}
-            error = {'globus_job_$(CLUSTER)_$(PROCESS).err'}
+            log = 'globus_job_$(CLUSTER)_$(PROCESS).log'
+            output = 'globus_job_$(CLUSTER)_$(PROCESS).out'
+            error = 'globus_job_$(CLUSTER)_$(PROCESS).err'
 
             request_cpus = 1
             request_memory = 200MB

--- a/globus.py
+++ b/globus.py
@@ -41,7 +41,7 @@ REFRESH_TOKEN = "refresh_token"
 BOLD_HEADER = functools.partial(click.style, bold=True)
 
 
-AS_JOB = "--as-job"
+AS_JOB = "--as-submit-description"
 
 
 # CLI

--- a/globus.py
+++ b/globus.py
@@ -82,9 +82,9 @@ def cli(context, verbose, as_submit_description):
             executable = {exe}
             arguments = {args_string}
 
-            log = 'globus_job_$(CLUSTER)_$(PROCESS).log'
-            output = 'globus_job_$(CLUSTER)_$(PROCESS).out'
-            error = 'globus_job_$(CLUSTER)_$(PROCESS).err'
+            log = globus_job_$(CLUSTER)_$(PROCESS).log
+            output = globus_job_$(CLUSTER)_$(PROCESS).out
+            error = globus_job_$(CLUSTER)_$(PROCESS).err
 
             request_cpus = 1
             request_memory = 200MB


### PR DESCRIPTION
This PR makes it so that you can add a command line flag to any command that, instead of actually performing the command, emits an equivalent submit description to run that command as an HTCondor local universe job instead.

Example: the transfer command
```
globus transfer xfer2001 mir '~/yay.txt':'~/yay.txt' --wait
```
would normally actually start the transfer and wait for it, but
```
globus --as-job transfer xfer2001 mir '~/yay.txt':'~/yay.txt' --wait
```
instead does nothing but produce this on stdout:
```
universe = local
executable = /home/jkarpel/.python/envs/globus/bin/globus
arguments = transfer xfer2001 mir ~/yay.txt:~/yay.txt --wait
log = globus_job_$(CLUSTER)_$(PROCESS).log
output = globus_job_$(CLUSTER)_$(PROCESS).out
error = globus_job_$(CLUSTER)_$(PROCESS).err
request_cpus = 1
request_memory = 200MB
request_disk = 1GB

queue 1
```

This output could be used as the actual submit file in a workflow, or it could be used as the basis for a hand-written template, thus resolving #11 